### PR TITLE
Skip updating binaries built from source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Fixed
+
 - Skip updating binaries built from source.
 
   Binaries built from source (either using `go build main.go` or `go install`
@@ -12,6 +14,11 @@
   Moreover, packages built using `go build main.go` have
   `command-line-arguments` set as their `path` in `go version -m binary-name`.
   This makes it impossible to update automatically.
+
+- Filesystem path handling on Windows.
+
+  Use correct separator for filesystem paths on Windows. This allows using this
+  tool on Windows.
 
 ## v0.1.0 (2022-03-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+- Skip updating binaries built from source.
+
+  Binaries built from source (either using `go build main.go` or `go install`
+  in the cloned repository) likely have been modified prior to being built.
+  Updating them would likely throw away these changes and end up being annoying
+  for engineers who want to keep their modified versions.
+
+  Moreover, packages built using `go build main.go` have
+  `command-line-arguments` set as their `path` in `go version -m binary-name`.
+  This makes it impossible to update automatically.
+
 ## v0.1.0 (2022-03-14)
 
 - Complete the basic functionality of upgrading globally installed executables.

--- a/internal/gobinaries/gobinary.go
+++ b/internal/gobinaries/gobinary.go
@@ -15,3 +15,14 @@ type GoBinary struct {
 func (b *GoBinary) UpgradePossible() bool {
 	return b.Version != b.LatestVersion
 }
+
+// BuiltFromSource determines whether the binary was built or installed from source.
+func (b *GoBinary) BuiltFromSource() bool {
+	return b.Version == "(devel)"
+}
+
+func (b *GoBinary) BuiltWithGoBuild() bool {
+	// Binaries built with `go build main.go` have a very distinct path.
+	// See https://github.com/Gelio/go-global-update/issues/3#issuecomment-1071566068
+	return b.PathURL == "command-line-arguments"
+}

--- a/internal/gobinaries/introspecter.go
+++ b/internal/gobinaries/introspecter.go
@@ -2,7 +2,7 @@ package gobinaries
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -25,7 +25,7 @@ func NewIntrospecter(cmdRunner gocli.GoCmdRunner, gobin string, logger *zap.Logg
 }
 
 func (i *Introspecter) Introspect(binaryName string) (GoBinary, error) {
-	binaryPath := path.Join(i.gobin, binaryName)
+	binaryPath := filepath.Join(i.gobin, binaryName)
 	moduleInfo, err := i.getModuleInfo(binaryPath)
 	if err != nil {
 		return GoBinary{}, fmt.Errorf("could not get module info about %v: %w", binaryPath, err)

--- a/internal/gobinariestest/binaries.go
+++ b/internal/gobinariestest/binaries.go
@@ -1,7 +1,7 @@
 package gobinariestest
 
 import (
-	"path"
+	"path/filepath"
 
 	"github.com/Gelio/go-global-update/internal/gobinaries"
 	"github.com/Gelio/go-global-update/internal/goclitest"
@@ -28,7 +28,7 @@ func GetShfmtMockBinary() MockBinary {
 			Name:          "shfmt",
 			PathURL:       "mvdan.cc/sh/v3/cmd/shfmt",
 			ModuleURL:     "mvdan.cc/sh/v3",
-			Path:          path.Join(GOBIN, "shfmt"),
+			Path:          filepath.Join(GOBIN, "shfmt"),
 			Version:       "v3.4.2",
 			LatestVersion: "v3.4.2",
 		},
@@ -51,7 +51,7 @@ func GetGofumptMockBinary() MockBinary {
 			Name:          "gofumpt",
 			ModuleURL:     "mvdan.cc/gofumpt",
 			PathURL:       "mvdan.cc/gofumpt",
-			Path:          path.Join(GOBIN, "gofumpt"),
+			Path:          filepath.Join(GOBIN, "gofumpt"),
 			Version:       "v0.3.0",
 			LatestVersion: "v0.3.0",
 		},

--- a/internal/goclitest/cmd_runner.go
+++ b/internal/goclitest/cmd_runner.go
@@ -2,7 +2,7 @@ package goclitest
 
 import (
 	"fmt"
-	"path"
+	"path/filepath"
 )
 
 type MockResponse struct {
@@ -45,7 +45,7 @@ func GetLatestVersionMockResponse(pathURL, version string) MockResponse {
 
 func GetModuleInfoMockResponse(gobin, binaryName, output string) MockResponse {
 	return MockResponse{
-		Args:   []string{"version", "-m", path.Join(gobin, binaryName)},
+		Args:   []string{"version", "-m", filepath.Join(gobin, binaryName)},
 		Output: output,
 	}
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -110,8 +110,22 @@ func updateBinaries(
 	var upgradeErrors []error
 	var binariesToUpdate []gobinaries.GoBinary
 
+	fmt.Fprintln(out)
+
 	for _, result := range introspectionResults {
 		if result.Error != nil || !result.Binary.UpgradePossible() {
+			continue
+		}
+
+		if binary := result.Binary; binary.BuiltFromSource() {
+			fmt.Fprintf(out, "Skipping upgrading %s\n    ", binary.Name)
+			if binary.BuiltWithGoBuild() {
+				fmt.Fprintln(out, `The binary was built from source (probably using "go build") and the binary path is unknown.`)
+			} else {
+				fmt.Fprintln(out, `The binary was installed from source (probably using "go install" in the cloned repository).`)
+			}
+			fmt.Fprintln(out, "    Install the binary using \"go install repositoryPath@latest\" instead.")
+			fmt.Fprintln(out)
 			continue
 		}
 
@@ -122,15 +136,13 @@ func updateBinaries(
 		return nil
 	}
 
-	fmt.Fprintln(out)
-
 	for _, binary := range binariesToUpdate {
 		fmt.Fprintf(out, "Upgrading %s to %s ... ", binary.Name, binary.LatestVersion)
 		upgradeOutput, err := goCLI.UpgradePackage(binary.PathURL)
 		if err != nil {
 			upgradeErrors = append(upgradeErrors, err)
 			fmt.Fprintln(out, "❌")
-			fmt.Fprintln(out, "\tCould not upgrade package")
+			fmt.Fprintln(out, "    Could not upgrade package")
 		} else {
 			fmt.Fprintln(out, "✅")
 		}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"path"
+	"path/filepath"
 
 	"github.com/Gelio/go-global-update/internal/gobinaries"
 	"github.com/Gelio/go-global-update/internal/gocli"
@@ -177,7 +177,7 @@ func getExecutableBinariesPath(cli *gocli.GoCLI) (string, error) {
 		return "", errors.New("GOPATH and GOPATH are not defined in 'go env' command")
 	}
 
-	gobin = path.Join(gopath, "bin")
+	gobin = filepath.Join(gopath, "bin")
 
 	return gobin, nil
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -3,6 +3,7 @@ package updater
 import (
 	"bytes"
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/Gelio/go-global-update/internal/gobinaries"
@@ -68,6 +69,77 @@ shfmt (version: v3.4.2, can upgrade to v3.4.3)
 Upgrading gofumpt to v0.4.0 ... ✅
 
 Upgrading shfmt to v3.4.3 ... ✅
+
+`, output.String())
+}
+
+func TestSkipUpgradingBuiltFromSource(t *testing.T) {
+	builtFromSourceMockBinary := gobinariestest.MockBinary{
+		Binary: gobinaries.GoBinary{
+			Name:          "built-from-source",
+			ModuleURL:     "github.com/Gelio/built-from-source",
+			PathURL:       "command-line-arguments",
+			Path:          filepath.Join(gobinariestest.GOBIN, "built-from-source"),
+			Version:       "(devel)",
+			LatestVersion: "v0.1.0",
+		},
+		ModuleInfo: `
+built-from-source: go1.17
+    path    command-line-arguments
+    mod     github.com/Gelio/built-from-source      (devel)
+    dep     github.com/cpuguy83/go-md2man/v2        v2.0.0-20190314233015-f79a8a8ca69d      h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+`,
+	}
+	installedFromSourceMockBinary := gobinariestest.MockBinary{
+		Binary: gobinaries.GoBinary{
+			Name:          "installed-from-source",
+			ModuleURL:     "github.com/Gelio/installed-from-source",
+			PathURL:       "github.com/Gelio/installed-from-source",
+			Path:          filepath.Join(gobinariestest.GOBIN, "installed-from-source"),
+			Version:       "(devel)",
+			LatestVersion: "v0.1.0",
+		},
+		ModuleInfo: `
+installed-from-source: go1.17
+    path    github.com/Gelio/built-from-source
+    mod     github.com/Gelio/built-from-source      (devel)
+    dep     github.com/cpuguy83/go-md2man/v2        v2.0.0-20190314233015-f79a8a8ca69d      h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+`,
+	}
+
+	logger := zap.NewNop()
+	options := Options{}
+	var output bytes.Buffer
+	lister := gobinariestest.TestSuccessDirectoryLister{
+		Entries: []string{builtFromSourceMockBinary.Binary.Name, installedFromSourceMockBinary.Binary.Name},
+	}
+	cmdRunner := goclitest.TestGoCmdRunner{
+		Responses: []goclitest.MockResponse{
+			gobinMockResponse(),
+			gobinariestest.GetLatestVersionMockResponse(builtFromSourceMockBinary.Binary),
+			gobinariestest.GetModuleInfoMockResponse(builtFromSourceMockBinary),
+			updateMockResponse(builtFromSourceMockBinary.Binary, "", nil),
+			gobinariestest.GetLatestVersionMockResponse(installedFromSourceMockBinary.Binary),
+			gobinariestest.GetModuleInfoMockResponse(installedFromSourceMockBinary),
+			updateMockResponse(installedFromSourceMockBinary.Binary, "", nil),
+		},
+	}
+
+	fsutils := mockFilesystemUtils{}
+
+	err := UpdateBinaries(logger, options, &output, &cmdRunner, &lister, fsutils)
+
+	assert.Nil(t, err)
+	assert.Equal(t, `built-from-source (version: (devel), can upgrade to v0.1.0)
+installed-from-source (version: (devel), can upgrade to v0.1.0)
+
+Skipping upgrading built-from-source
+    The binary was built from source (probably using "go build") and the binary path is unknown.
+    Install the binary using "go install repositoryPath@latest" instead.
+
+Skipping upgrading installed-from-source
+    The binary was installed from source (probably using "go install" in the cloned repository).
+    Install the binary using "go install repositoryPath@latest" instead.
 
 `, output.String())
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -105,15 +105,15 @@ func TestIntegration(t *testing.T) {
 		updateArgs        []string
 	}{
 		{
-			name:              "single package",
+			name:              "single binary",
 			binariesToInstall: []binaryToInstall{gofumptBinaryToInstall},
 		},
 		{
-			name:              "multiple packages",
+			name:              "multiple binary",
 			binariesToInstall: []binaryToInstall{gofumptBinaryToInstall, shfmtBinaryToInstall},
 		},
 		{
-			name:       "single package when multiple packages installed",
+			name:       "single binary when multiple binaries installed",
 			updateArgs: []string{binaryName("gofumpt")},
 			binariesToInstall: []binaryToInstall{
 				gofumptBinaryToInstall,


### PR DESCRIPTION
Skip updating binaries that were:

* built from source using `go build file.go`
* installed from a cloned repository using `go install`

Such binaries have a `(devel)` version listed in `go version -m binary-name`. Moreover, binaries built using `go build` have their `path` set to `command-line-arguments`, which makes it impossible to upgrade.

These binaries will be skipped now instead of trying to upgrade them and failing.

Closes #3 