### PR TITLE
Add support for go 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ["1.16", "1.17"]
+        go-version: ["1.16", "1.17", "1.18"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Continue other jobs if one matrix job fails
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+### Fixed
+
+- Support go 1.18
+
+  Go 1.18 changed the format of the `go version -m [binary-name]` command to no
+  longer include the `mod` information for binaries built from source using `go build main.go`.
+
+  go-global-update now parses such outputs and does not attempt to check for
+  the latest version of such binaries.
+
 ## v0.1.1 (2022-03-21)
 
 A patch release containing fixes for some of the edge cases found in

--- a/internal/gobinaries/introspecter_test.go
+++ b/internal/gobinaries/introspecter_test.go
@@ -1,6 +1,8 @@
 package gobinaries_test
 
 import (
+	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/Gelio/go-global-update/internal/gobinaries"
@@ -64,4 +66,103 @@ func TestExtractLatestVersion(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, mockBinary.Binary, binary)
 	assert.True(t, binary.UpgradePossible())
+}
+
+func TestBuiltFromSourceOnGo116And117(t *testing.T) {
+	mockBinary := gobinariestest.MockBinary{
+		Binary: gobinaries.GoBinary{
+			Name:      "go-global-update",
+			Path:      filepath.Join(gobinariestest.GOBIN, "go-global-update"),
+			PathURL:   "command-line-arguments",
+			ModuleURL: "github.com/Gelio/go-global-update",
+			Version:   "(devel)",
+		},
+		ModuleInfo: `
+go-global-update: go1.17
+    path    command-line-arguments
+    mod     github.com/Gelio/go-global-update       (devel)
+    dep     github.com/cpuguy83/go-md2man/v2        v2.0.0-20190314233015-f79a8a8ca69d      h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+    dep     github.com/russross/blackfriday/v2      v2.0.1  h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+    dep     github.com/shurcooL/sanitized_anchor_name       v1.0.0  h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+    dep     github.com/urfave/cli/v2        v2.3.0  h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+    dep     go.uber.org/atomic      v1.9.0  h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+    dep     go.uber.org/multierr    v1.8.0  h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+    dep     go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
+    build   -compiler=gc
+    build   CGO_ENABLED=1
+    build   CGO_CFLAGS=
+    build   CGO_CPPFLAGS=
+    build   CGO_CXXFLAGS=
+    build   CGO_LDFLAGS=
+    build   GOARCH=amd64
+    build   GOOS=linux
+    build   GOAMD64=v1
+`,
+	}
+
+	latestVersionMockResponse := goclitest.GetLatestVersionMockResponse(mockBinary.Binary.PathURL, "go: command-line-arguments@latest: malformed module path \"command-line-arguments\": missing dot in first path element")
+	latestVersionMockResponse.Error = fmt.Errorf("exit code 1")
+
+	cmdRunner := goclitest.TestGoCmdRunner{
+		Responses: []goclitest.MockResponse{
+			gobinariestest.GetModuleInfoMockResponse(mockBinary),
+			latestVersionMockResponse,
+		},
+	}
+
+	introspecter := gobinaries.NewIntrospecter(&cmdRunner, gobinariestest.GOBIN, zap.NewNop())
+	binary, err := introspecter.Introspect(mockBinary.Binary.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, mockBinary.Binary, binary)
+	assert.True(t, binary.BuiltFromSource())
+	assert.True(t, binary.BuiltWithGoBuild())
+}
+
+func TestMissingModLineOnGo118(t *testing.T) {
+	mockBinary := gobinariestest.MockBinary{
+		Binary: gobinaries.GoBinary{
+			Name:    "go-global-update",
+			Path:    filepath.Join(gobinariestest.GOBIN, "go-global-update"),
+			PathURL: "command-line-arguments",
+			Version: "(devel)",
+		},
+		ModuleInfo: `
+go-global-update: go1.18
+    path    command-line-arguments
+    dep     github.com/Gelio/go-global-update       (devel)
+    dep     github.com/cpuguy83/go-md2man/v2        v2.0.0-20190314233015-f79a8a8ca69d      h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+    dep     github.com/russross/blackfriday/v2      v2.0.1  h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+    dep     github.com/shurcooL/sanitized_anchor_name       v1.0.0  h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+    dep     github.com/urfave/cli/v2        v2.3.0  h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+    dep     go.uber.org/atomic      v1.9.0  h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+    dep     go.uber.org/multierr    v1.8.0  h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+    dep     go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
+    build   -compiler=gc
+    build   CGO_ENABLED=1
+    build   CGO_CFLAGS=
+    build   CGO_CPPFLAGS=
+    build   CGO_CXXFLAGS=
+    build   CGO_LDFLAGS=
+    build   GOARCH=amd64
+    build   GOOS=linux
+    build   GOAMD64=v1
+`,
+	}
+
+	latestVersionMockResponse := goclitest.GetLatestVersionMockResponse(mockBinary.Binary.PathURL, "go: command-line-arguments@latest: malformed module path \"command-line-arguments\": missing dot in first path element")
+	latestVersionMockResponse.Error = fmt.Errorf("exit code 1")
+
+	cmdRunner := goclitest.TestGoCmdRunner{
+		Responses: []goclitest.MockResponse{
+			gobinariestest.GetModuleInfoMockResponse(mockBinary),
+			latestVersionMockResponse,
+		},
+	}
+
+	introspecter := gobinaries.NewIntrospecter(&cmdRunner, gobinariestest.GOBIN, zap.NewNop())
+	binary, err := introspecter.Introspect(mockBinary.Binary.Name)
+	assert.Nil(t, err)
+	assert.Equal(t, mockBinary.Binary, binary)
+	assert.True(t, binary.BuiltFromSource())
+	assert.True(t, binary.BuiltWithGoBuild())
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -86,10 +86,14 @@ func printBinariesSummary(
 
 		binary := result.Binary
 		var latestVersionInfo string
-		if binary.UpgradePossible() {
-			latestVersionInfo = fmt.Sprintf("can upgrade to %s", binary.LatestVersion)
+		if binary.LatestVersion != "" {
+			if binary.UpgradePossible() {
+				latestVersionInfo = fmt.Sprintf("can upgrade to %s", binary.LatestVersion)
+			} else {
+				latestVersionInfo = "up-to-date"
+			}
 		} else {
-			latestVersionInfo = "up-to-date"
+			latestVersionInfo = "cannot upgrade"
 		}
 
 		name := binary.Name

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -130,7 +130,7 @@ installed-from-source: go1.17
 	err := UpdateBinaries(logger, options, &output, &cmdRunner, &lister, fsutils)
 
 	assert.Nil(t, err)
-	assert.Equal(t, `built-from-source (version: (devel), can upgrade to v0.1.0)
+	assert.Equal(t, `built-from-source (version: (devel), cannot upgrade)
 installed-from-source (version: (devel), can upgrade to v0.1.0)
 
 Skipping upgrading built-from-source

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -202,7 +202,7 @@ func TestBuiltFromSourceCommandLineArguments(t *testing.T) {
 
 	output, err := newGoGlobalUpdateCommand(t, gobin, builtBinaryName).Output()
 	assert.Nil(t, err)
-	assert.Contains(t, string(output), fmt.Sprintf("%s (version: (devel), can upgrade to v0.1.0)", builtBinaryName))
+	assert.Contains(t, string(output), fmt.Sprintf("%s (version: (devel), cannot upgrade)", builtBinaryName))
 	assert.Contains(t, string(output), "binary was built from source")
 
 	version, err := newTestCommand(t, gobin, "go", "version", "-m", filepath.Join(gobin, builtBinaryName)).Output()
@@ -231,7 +231,7 @@ func TestInstalledFromSource(t *testing.T) {
 	builtBinaryName := binaryName("go-global-update")
 	output, err := newGoGlobalUpdateCommand(t, gobin, builtBinaryName).Output()
 	assert.Nil(t, err)
-	assert.Contains(t, string(output), fmt.Sprintf("%s (version: (devel), can upgrade to v0.1.0)", builtBinaryName))
+	assert.Contains(t, string(output), fmt.Sprintf("%s (version: (devel), can upgrade to v", builtBinaryName))
 	assert.Contains(t, string(output), "binary was installed from source")
 
 	version, err := newTestCommand(t, gobin, "go", "version", "-m", filepath.Join(gobin, builtBinaryName)).Output()


### PR DESCRIPTION
Handle different `go version -m [binary-name]` command output on go 1.18 for binaries built from source using `go build main.go`. The `mod` line is missing.

go-global-update will assume the binary is not updatable if it was built from source. It will not even check for the latest version of that binary on all go versions now to behave consistently.