### PR TITLE
Add troubleshooting information about known update problems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,19 @@ jobs:
 
       - run: go build
       - run: go test ./...
-      # TODO: run integration tests
+
+  verify-table-of-contents:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16"
+      - run: npm install
+
+      - run: npm run generate-toc
+      - name: Verify table of contents
+        run: git diff --exit-code
+
+      - name: Check formatting of Markdown documents
+        run: npm run format-docs:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,13 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Verify formatting
-        # NOTE: only verify formatting on Linux.
+
+        # NOTE: only verify formatting on Linux and the latest go version.
         # It only needs to happen once, and formatting
         # is not consistent on Windows.
-        if: ${{ startsWith(matrix.os, 'ubuntu') }}
+        if:
+          ${{ startsWith(matrix.os, 'ubuntu')  && matrix.go-version == '1.18'}}
+
         # NOTE: hacky bash `if` because gofumpt always returns 0 exit code
         # @see https://github.com/mvdan/gofumpt/issues/114
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /test/integration-tests
+node_modules

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "proseWrap": "always"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) containing a description of
-  common problems faced while updating packages with `go-global-update`.
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) containing a description of common
+  problems faced while updating packages with `go-global-update`.
 
 ## v0.1.2 (2022-03-21)
 
@@ -16,10 +16,11 @@ A patch release adding support for go 1.18.
 - Support go 1.18 <https://github.com/Gelio/go-global-update/pull/7>
 
   Go 1.18 changed the format of the `go version -m [binary-name]` command to no
-  longer include the `mod` information for binaries built from source using `go build main.go`.
+  longer include the `mod` information for binaries built from source using
+  `go build main.go`.
 
-  go-global-update now parses such outputs and does not attempt to check for
-  the latest version of such binaries.
+  go-global-update now parses such outputs and does not attempt to check for the
+  latest version of such binaries.
 
 ## v0.1.1 (2022-03-21)
 
@@ -30,8 +31,8 @@ A patch release containing fixes for some of the edge cases found in
 
 - Skip updating binaries built from source.
 
-  Binaries built from source (either using `go build main.go` or `go install`
-  in the cloned repository) likely have been modified prior to being built.
+  Binaries built from source (either using `go build main.go` or `go install` in
+  the cloned repository) likely have been modified prior to being built.
   Updating them would likely throw away these changes and end up being annoying
   for engineers who want to keep their modified versions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Added
+
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) containing a description of
+  common problems faced while updating packages with `go-global-update`.
+
 ## v0.1.2 (2022-03-21)
 
 A patch release adding support for go 1.18.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,29 @@
 ### Added
 
 - [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) containing a description of common
-  problems faced while updating packages with `go-global-update`.
+  problems faced while updating binaries with `go-global-update`.
+
+- Include detecting common binary update problems right into `go-global-update`.
+
+  Additional messages will be printed in the output when updating a binary fails
+  due to a known reason.
+
+  ![screenshot](https://user-images.githubusercontent.com/889383/159443820-3c11044b-016d-4df3-8d33-983aa2b251ba.png)
+
+### Maintenance
+
+- Add `npm` scripts to format Markdown documents using
+  [prettier](https://prettier.io/) and generate table of contents using
+  [markdown-toc](https://github.com/jonschlinkert/markdown-toc).
+
+  Those scripts are run CI for more static verification.
+
+- Only verify formatting once in CI (for one matrix build). This is because
+  [gofumpt@v0.3.1](https://github.com/mvdan/gofumpt/tree/v0.3.1) cannot be
+  installed on go 1.16 and it does not make sense to verify formatting multiple
+  times. This also slightly speeds up the CI.
+
+- Add more context in test output if an assertion fails.
 
 ## v0.1.2 (2022-03-21)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,17 @@ Want to take a stab at making a code change? Pull requests are also welcome!
 
 Before submitting a pull request, make sure to complete the following steps:
 
-1. Format the code usign [gofumpt](https://github.com/mvdan/gofumpt)
+1. Format the Go code usign [gofumpt](https://github.com/mvdan/gofumpt)
 1. Ensure the tests pass by running `go test ./...`
+1. Regenerate the Markdown table of contents in case you changed
+   Markdown files. Run `npm run generate-toc`
+1. Format the Markdown files using [prettier](https://prettier.io/). Run
+   `npm run format-docs:write`
 
 It is best if your change is covered by tests. If there are none, consider
 adding new test cases. Do not worry if you do not know how, we can figure it
 out during the pull request review.
+
+To run `npm` commands you will need [Node](https://nodejs.org/en/)
+installed, which comes bundled with `npm`. Run `npm install` to install
+the necessary dependencies before running those `npm run ...` commands.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,15 @@ Before submitting a pull request, make sure to complete the following steps:
 
 1. Format the Go code usign [gofumpt](https://github.com/mvdan/gofumpt)
 1. Ensure the tests pass by running `go test ./...`
-1. Regenerate the Markdown table of contents in case you changed
-   Markdown files. Run `npm run generate-toc`
+1. Regenerate the Markdown table of contents in case you changed Markdown files.
+   Run `npm run generate-toc`
 1. Format the Markdown files using [prettier](https://prettier.io/). Run
    `npm run format-docs:write`
 
 It is best if your change is covered by tests. If there are none, consider
-adding new test cases. Do not worry if you do not know how, we can figure it
-out during the pull request review.
+adding new test cases. Do not worry if you do not know how, we can figure it out
+during the pull request review.
 
-To run `npm` commands you will need [Node](https://nodejs.org/en/)
-installed, which comes bundled with `npm`. Run `npm install` to install
-the necessary dependencies before running those `npm run ...` commands.
+To run `npm` commands you will need [Node](https://nodejs.org/en/) installed,
+which comes bundled with `npm`. Run `npm install` to install the necessary
+dependencies before running those `npm run ...` commands.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,18 @@ Update globally installed go binaries.
 
 The missing go command similar to `npm -g update` or [cargo install-update](https://github.com/nabijaczleweli/cargo-update).
 
+<!-- vim-markdown-toc GFM -->
+
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+- [Upgrading `go-global-update`](#upgrading-go-global-update)
+- [Troubleshooting](#troubleshooting)
+- [How it works](#how-it-works)
+- [Contributing](#contributing)
+
+<!-- vim-markdown-toc -->
+
 ## Requirements
 
 - Go 1.16 or higher
@@ -48,6 +60,11 @@ go-global-update --help
 ## Upgrading `go-global-update`
 
 `go-global-update` will take care of updating itself when it updates other binaries.
+
+## Troubleshooting
+
+Do you have problems updating some binaries using `go-global-update`? Take a
+look at [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for more information.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 Update globally installed go binaries.
 
-The missing go command similar to `npm -g update` or [cargo install-update](https://github.com/nabijaczleweli/cargo-update).
+The missing go command similar to `npm -g update` or
+[cargo install-update](https://github.com/nabijaczleweli/cargo-update).
 
 <!-- toc -->
 
@@ -59,7 +60,8 @@ go-global-update --help
 
 ## Upgrading `go-global-update`
 
-`go-global-update` will take care of updating itself when it updates other binaries.
+`go-global-update` will take care of updating itself when it updates other
+binaries.
 
 ## Troubleshooting
 
@@ -86,4 +88,5 @@ look at [TROUBLESHOOTING.md](./TROUBLESHOOTING.md) for more information.
 
 ## Contributing
 
-Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for more information.
+Contributions are welcome! See [CONTRIBUTING.md](./CONTRIBUTING.md) for more
+information.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Update globally installed go binaries.
 
 The missing go command similar to `npm -g update` or [cargo install-update](https://github.com/nabijaczleweli/cargo-update).
 
-<!-- vim-markdown-toc GFM -->
+<!-- toc -->
 
 - [Requirements](#requirements)
 - [Installation](#installation)
@@ -16,7 +16,7 @@ The missing go command similar to `npm -g update` or [cargo install-update](http
 - [How it works](#how-it-works)
 - [Contributing](#contributing)
 
-<!-- vim-markdown-toc -->
+<!-- tocstop -->
 
 ## Requirements
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1,0 +1,148 @@
+# Troubleshooting go-global-update
+
+This document describes known problems that can occur while trying to update
+globally-installed binaries using go-global-update.
+
+<!-- vim-markdown-toc GFM -->
+
+- [E001 - binaries built from source](#e001---binaries-built-from-source)
+- [E002 - module found but does not contain package](#e002---module-found-but-does-not-contain-package)
+- [E003 - module declares its path as ... but was required as ...](#e003---module-declares-its-path-as--but-was-required-as-)
+- [E004 - go.mod contains `replace` directives](#e004---gomod-contains-replace-directives)
+
+<!-- vim-markdown-toc -->
+
+## E001 - binaries built from source
+
+go-global-update can only update binaries in `GOBIN` installed using
+`go install [path URL]@latest`. go-global-update cannot update binaries which
+were built from source (inside of the source repository of the binary) using either:
+
+- `go install` (without arguments)
+- `go build` (either without arguments or pointing to a specific Go file)
+
+This is because the version of the installed binary is discarded and will
+appear as `(devel)` in `go version -m [binary-name]`. Moreover, for binaries
+built using `go build`, the path URL is also discarded and replaced with
+`command-line-arguments`, which makes it impossible to know what is the path
+URL for the binary. The path URL is required when updating the binary.
+
+```sh
+$ git clone git@github.com:StevenACoffman/toolbox.git
+$ go build -o bin/jp cmd/jira-pull/jp.go
+$ cd bin
+$ go version -m jp
+jp: go1.17.5
+	path	command-line-arguments
+	mod	github.com/StevenACoffman/toolbox	(devel)
+	dep	github.com/emirpasic/gods	v1.12.0	h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
+	dep	github.com/go-git/gcfg	v1.5.0	h1:Q5ViNfGF8zFgyJWPqYwA7qGFoMTEiBmdlkcfRmpIMa4=
+	dep	github.com/go-git/go-billy/v5	v5.0.0	h1:7NQHvd9FVid8VL4qVUMm8XifBK+2xCoZ2lSk0agRrHM=
+  # the rest of the output ...
+```
+
+Additionally, if you are using a binary built from source instead of some
+publicly available version, this can mean that you introduced some modifications
+to it and expect them to be retained. Updating to the latest version could
+remove those modification, which could quickly become annoying.
+
+## E002 - module found but does not contain package
+
+Sometimes repository maintainers decide to extract the CLI binary of some module
+to a separate module in a separate repository or a different directory in the
+same repository. Regardless, the path URL to the directory with the binary
+module changes. It means updating the previous path URL will not work, because
+it will not have a CLI binary there.
+
+```sh
+$ go-global-update
+Upgrading cobra to v1.4.0 ... ❌
+    Could not upgrade package
+go: downloading github.com/spf13/cobra v1.4.0
+go install: github.com/spf13/cobra/cobra@latest:
+  module github.com/spf13/cobra@latest found (v1.4.0),
+  but does not contain package github.com/spf13/cobra/cobra
+```
+
+In that case, you have to find the new path for the CLI, remove the old binary,
+and install the new one once:
+
+```sh
+cd $(which cobra)/..
+rm cobra
+go install github.com/spf13/cobra-cli@latest
+```
+
+Next runs of `go-global-update` will correctly keep `cobra-cli` up-to-date.
+
+Known extracted binaries:
+
+- [`cobra`](https://github.com/spf13/cobra) was extracted to
+  [`cobra-cli`](https://github.com/spf13/cobra-cli) in [v1.3.0](https://github.com/spf13/cobra-cli/releases/tag/v1.3.0)
+
+## E003 - module declares its path as ... but was required as ...
+
+Similarly to [E002](#e002---module-found-but-does-not-contain-package), the
+whole repository containing the binary may be moved to a different name or to a
+different organization. This would manifest itself in the error:
+
+```sh
+$ go-global-update
+Upgrading gnostic to v0.6.6 ... ❌
+  Could not upgrade package
+go install: github.com/googleapis/gnostic@latest: github.com/googleapis/gnostic@v0.6.6: parsing go.mod:
+  module declares its path as: github.com/google/gnostic
+          but was required as: github.com/googleapis/gnostic
+```
+
+This happens because GitHub automatically redirects [the old
+URL](https://github.com/googleapis/gnostic) to [the new URL of the
+repository](https://github.com/google/gnostic), but [the `go.mod` only lists the
+new path to the
+repository](https://github.com/google/gnostic/blob/418d86c152e3f607fa625e9aca135091e574811f/go.mod#L1),
+which `go` does not like.
+
+To mitigate the problem, remove the old binary and install it once using the new
+path URL:
+
+```sh
+cd $(which gnostic)/..
+rm gnostic
+go install github.com/google/gnostic@latest
+```
+
+Next runs of `go-global-update` will correctly keep `gnostic` up-to-date.
+
+Known moved repositories:
+
+- <https://github.com/google/gnostic> (moved to the
+  [google](https://github.com/google) organization from
+  [googleapis](https://github.com/googleapis))
+
+## E004 - go.mod contains `replace` directives
+
+Some binaries contain `go.mod` files which contain [`replace`
+directives](https://go.dev/ref/mod#go-mod-file-replace). `go install` does not
+handle such directives and exits with an error when trying to install or update
+such a binary.
+
+```sh
+$ go-global-update
+Upgrading dive to v0.10.0 ... ❌
+  Could not upgrade package
+go: downloading github.com/wagoodman/dive v0.10.0
+go install: github.com/wagoodman/dive@latest (in github.com/wagoodman/dive@v0.10.0):
+    The go.mod file for the module providing named packages contains one or
+    more replace directives. It must not contain directives that would cause
+    it to be interpreted differently than if it were the main module.
+```
+
+There are 2 ways to solve this problem:
+
+1. Ask the module maintainer to remove the `replace` directive. This way `go install` will be able to correctly install it.
+
+2. Clone the repository locally and run `go install` on it.
+
+   This will install the binary into your `GOBIN`. Future runs of
+   `go-global-update` will not update such a binary, because it was built from
+   source and will trigger [E001](#e001---binaries-built-from-source).

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -16,16 +16,17 @@ globally-installed binaries using go-global-update.
 
 go-global-update can only update binaries in `GOBIN` installed using
 `go install [path URL]@latest`. go-global-update cannot update binaries which
-were built from source (inside of the source repository of the binary) using either:
+were built from source (inside of the source repository of the binary) using
+either:
 
 - `go install` (without arguments)
 - `go build` (either without arguments or pointing to a specific Go file)
 
-This is because the version of the installed binary is discarded and will
-appear as `(devel)` in `go version -m [binary-name]`. Moreover, for binaries
-built using `go build`, the path URL is also discarded and replaced with
-`command-line-arguments`, which makes it impossible to know what is the path
-URL for the binary. The path URL is required when updating the binary.
+This is because the version of the installed binary is discarded and will appear
+as `(devel)` in `go version -m [binary-name]`. Moreover, for binaries built
+using `go build`, the path URL is also discarded and replaced with
+`command-line-arguments`, which makes it impossible to know what is the path URL
+for the binary. The path URL is required when updating the binary.
 
 ```sh
 $ git clone git@github.com:StevenACoffman/toolbox.git
@@ -78,7 +79,8 @@ Next runs of `go-global-update` will correctly keep `cobra-cli` up-to-date.
 Known extracted binaries:
 
 - [`cobra`](https://github.com/spf13/cobra) was extracted to
-  [`cobra-cli`](https://github.com/spf13/cobra-cli) in [v1.3.0](https://github.com/spf13/cobra-cli/releases/tag/v1.3.0)
+  [`cobra-cli`](https://github.com/spf13/cobra-cli) in
+  [v1.3.0](https://github.com/spf13/cobra-cli/releases/tag/v1.3.0)
 
 ## E003 - module declares its path as ... but was required as ...
 
@@ -95,11 +97,10 @@ go install: github.com/googleapis/gnostic@latest: github.com/googleapis/gnostic@
           but was required as: github.com/googleapis/gnostic
 ```
 
-This happens because GitHub automatically redirects [the old
-URL](https://github.com/googleapis/gnostic) to [the new URL of the
-repository](https://github.com/google/gnostic), but [the `go.mod` only lists the
-new path to the
-repository](https://github.com/google/gnostic/blob/418d86c152e3f607fa625e9aca135091e574811f/go.mod#L1),
+This happens because GitHub automatically redirects
+[the old URL](https://github.com/googleapis/gnostic) to
+[the new URL of the repository](https://github.com/google/gnostic), but
+[the `go.mod` only lists the new path to the repository](https://github.com/google/gnostic/blob/418d86c152e3f607fa625e9aca135091e574811f/go.mod#L1),
 which `go` does not like.
 
 To mitigate the problem, remove the old binary and install it once using the new
@@ -121,10 +122,10 @@ Known moved repositories:
 
 ## E004 - go.mod contains `replace` directives
 
-Some binaries contain `go.mod` files which contain [`replace`
-directives](https://go.dev/ref/mod#go-mod-file-replace). `go install` does not
-handle such directives and exits with an error when trying to install or update
-such a binary.
+Some binaries contain `go.mod` files which contain
+[`replace` directives](https://go.dev/ref/mod#go-mod-file-replace). `go install`
+does not handle such directives and exits with an error when trying to install
+or update such a binary.
 
 ```sh
 $ go-global-update
@@ -139,7 +140,8 @@ go install: github.com/wagoodman/dive@latest (in github.com/wagoodman/dive@v0.10
 
 There are 2 ways to solve this problem:
 
-1. Ask the module maintainer to remove the `replace` directive. This way `go install` will be able to correctly install it.
+1. Ask the module maintainer to remove the `replace` directive. This way
+   `go install` will be able to correctly install it.
 
 2. Clone the repository locally and run `go install` on it.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -3,14 +3,14 @@
 This document describes known problems that can occur while trying to update
 globally-installed binaries using go-global-update.
 
-<!-- vim-markdown-toc GFM -->
+<!-- toc -->
 
 - [E001 - binaries built from source](#e001---binaries-built-from-source)
 - [E002 - module found but does not contain package](#e002---module-found-but-does-not-contain-package)
 - [E003 - module declares its path as ... but was required as ...](#e003---module-declares-its-path-as--but-was-required-as-)
 - [E004 - go.mod contains `replace` directives](#e004---gomod-contains-replace-directives)
 
-<!-- vim-markdown-toc -->
+<!-- tocstop -->
 
 ## E001 - binaries built from source
 

--- a/internal/updater/common_problems.go
+++ b/internal/updater/common_problems.go
@@ -1,0 +1,73 @@
+package updater
+
+import (
+	"fmt"
+	"regexp"
+)
+
+var troubleshootingBaseURL string = "https://github.com/Gelio/go-global-update/blob/main/TROUBLESHOOTING.md"
+
+type CommonUpdateProblem struct {
+	troubleshootingHeadingHash string
+	name                       string
+	occurs                     func(goInstallOutput string) bool
+}
+
+func (p *CommonUpdateProblem) troubleshootingURL() string {
+	return troubleshootingBaseURL + p.troubleshootingHeadingHash
+}
+
+var binaryBuiltFromSourceProblem CommonUpdateProblem = CommonUpdateProblem{
+	troubleshootingHeadingHash: "#e001---binaries-built-from-source",
+	name:                       "E001",
+}
+
+func (p *CommonUpdateProblem) String() string {
+	return fmt.Sprintf(`    This seems like a known problem %s.
+    See %s
+    for more information.`, p.name, p.troubleshootingURL())
+}
+
+var commonUpdateProblems []CommonUpdateProblem = []CommonUpdateProblem{
+	// E001 is handled out-of-band since the update is not even attempted
+	// if E001 is detected.
+
+	{
+		name:                       "E002",
+		troubleshootingHeadingHash: "#e002---module-found-but-does-not-contain-package",
+		occurs: func(goInstallOutput string) bool {
+			r := regexp.MustCompile("module .* found .*, but does not contain package .*")
+			return r.MatchString(goInstallOutput)
+		},
+	},
+
+	{
+		name:                       "E003",
+		troubleshootingHeadingHash: "#e003---module-declares-its-path-as--but-was-required-as-",
+		occurs: func(goInstallOutput string) bool {
+			r := regexp.MustCompile("(?s)module declares its path as: .*\\n\\s+but was required as: .*")
+			return r.MatchString(goInstallOutput)
+		},
+	},
+
+	{
+		name:                       "E004",
+		troubleshootingHeadingHash: "#e004---gomod-contains-replace-directives",
+		occurs: func(goInstallOutput string) bool {
+			r := regexp.MustCompile("(?s)The go.mod file .* contains .* replace directives.")
+			return r.MatchString(goInstallOutput)
+		},
+	},
+}
+
+func FindCommonUpdateProblems(goInstallOutput string) []CommonUpdateProblem {
+	var problems []CommonUpdateProblem
+
+	for _, p := range commonUpdateProblems {
+		if p.occurs(goInstallOutput) {
+			problems = append(problems, p)
+		}
+	}
+
+	return problems
+}

--- a/internal/updater/common_problems_test.go
+++ b/internal/updater/common_problems_test.go
@@ -1,9 +1,15 @@
 package updater
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFindCommonProblems(t *testing.T) {
@@ -69,5 +75,39 @@ go install: command-line-arguments@latest: malformed module path "command-line-a
 
 			assert.ElementsMatch(t, problemNames, c.expectedProblemNames, "mismatched errors found (listA) while expected listB")
 		})
+	}
+}
+
+func TestCommonProblemHashes(t *testing.T) {
+	workingDirectory, err := os.Getwd()
+	require.Nil(t, err)
+	troubleshootingFilePath := filepath.Join(workingDirectory, "..", "..", "TROUBLESHOOTING.md")
+	troubleshootingFileBuffer, err := os.ReadFile(troubleshootingFilePath)
+	require.Nil(t, err)
+	troubleshootingFileContents := string(troubleshootingFileBuffer)
+
+	hashRegexp := regexp.MustCompile(`^- \[.*\]\((.*)\)$`)
+	var knownProblemHashes []string
+	endOfLineSequence := "\n"
+	if runtime.GOOS == "windows" {
+		endOfLineSequence = "\r\n"
+	}
+
+	for _, line := range strings.Split(troubleshootingFileContents, endOfLineSequence) {
+		matches := hashRegexp.FindStringSubmatch(line)
+		if matches != nil {
+			assert.Len(t, matches, 2, "hashRegexp matched an unexpected line")
+			knownProblemHashes = append(knownProblemHashes, matches[1])
+		}
+	}
+
+	require.GreaterOrEqualf(t, len(knownProblemHashes), 4,
+		"could not find hashes in %s\nfile contents: %s",
+		troubleshootingFilePath, troubleshootingFileContents)
+
+	allCommonProblems := append(commonUpdateProblems, binaryBuiltFromSourceProblem)
+	for _, p := range allCommonProblems {
+		assert.Containsf(t, knownProblemHashes, p.troubleshootingHeadingHash,
+			"not a known hash. Check if there is a typo in the heading hash for problem %v", p)
 	}
 }

--- a/internal/updater/common_problems_test.go
+++ b/internal/updater/common_problems_test.go
@@ -1,0 +1,73 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFindCommonProblems(t *testing.T) {
+	cases := []struct {
+		name                 string
+		goInstallOutput      string
+		expectedProblemNames []string
+	}{
+		{
+			name: "E002 module found but does not contain package cobra",
+			goInstallOutput: `
+go: downloading github.com/spf13/cobra v1.4.0
+go install: github.com/spf13/cobra/cobra@latest: module github.com/spf13/cobra@latest found (v1.4.0), but does not contain package github.com/spf13/cobra/cobra
+`,
+			expectedProblemNames: []string{"E002"},
+		},
+		{
+			name: "E002 module found but does not contain package StevenACoffman checker",
+			goInstallOutput: `
+go: downloading github.com/StevenACoffman/toolbox v0.0.0-20210809155116-d52e63616b7a
+go install: github.com/StevenACoffman/toolbox/cmd/checker@latest: module github.com/StevenACoffman/toolbox@latest found (v0.0.0-20210809155116-d52e63616b7a), but does not contain package github.com/StevenACoffman/toolbox/cmd/checker
+`,
+			expectedProblemNames: []string{"E002"},
+		},
+		{
+			name: "E003 go.mod path mismatch",
+			goInstallOutput: `
+go: downloading github.com/googleapis/gnostic v0.6.6
+go install: github.com/googleapis/gnostic/generate-gnostic@latest: github.com/googleapis/gnostic@v0.6.6: parsing go.mod:
+	module declares its path as: github.com/google/gnostic
+	        but was required as: github.com/googleapis/gnostic
+`,
+			expectedProblemNames: []string{"E003"},
+		},
+		{
+			name: "E004 go.mod contains replace directive",
+			goInstallOutput: `
+go: downloading github.com/wagoodman/dive v0.10.0
+go install: github.com/wagoodman/dive@latest (in github.com/wagoodman/dive@v0.10.0):
+	The go.mod file for the module providing named packages contains one or
+	more replace directives. It must not contain directives that would cause
+	it to be interpreted differently than if it were the main module.
+`,
+			expectedProblemNames: []string{"E004"},
+		},
+		{
+			name: "malformed module path command-line-arguments",
+			goInstallOutput: `
+go install: command-line-arguments@latest: malformed module path "command-line-arguments": missing dot in first path element
+`,
+			expectedProblemNames: []string{},
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			problemsFound := FindCommonUpdateProblems(c.goInstallOutput)
+			var problemNames []string
+			for _, p := range problemsFound {
+				problemNames = append(problemNames, p.name)
+			}
+
+			assert.ElementsMatch(t, problemNames, c.expectedProblemNames, "mismatched errors found (listA) while expected listB")
+		})
+	}
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -129,7 +129,7 @@ func updateBinaries(
 				fmt.Fprintln(out, `The binary was installed from source (probably using "go install" in the cloned repository).`)
 			}
 			fmt.Fprintln(out, "    Install the binary using \"go install repositoryPath@latest\" instead.")
-			fmt.Fprintln(out)
+			fmt.Fprintf(out, "%s\n\n", binaryBuiltFromSourceProblem.String())
 			continue
 		}
 
@@ -153,6 +153,10 @@ func updateBinaries(
 
 		if len(upgradeOutput) > 0 && (verbose || err != nil) {
 			fmt.Fprintln(out, upgradeOutput)
+
+			for _, problem := range FindCommonUpdateProblems(upgradeOutput) {
+				fmt.Fprintf(out, "%s\n", problem.String())
+			}
 		}
 		fmt.Fprintln(out)
 	}

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -136,10 +136,16 @@ installed-from-source (version: (devel), can upgrade to v0.1.0)
 Skipping upgrading built-from-source
     The binary was built from source (probably using "go build") and the binary path is unknown.
     Install the binary using "go install repositoryPath@latest" instead.
+    This seems like a known problem E001.
+    See https://github.com/Gelio/go-global-update/blob/main/TROUBLESHOOTING.md#e001---binaries-built-from-source
+    for more information.
 
 Skipping upgrading installed-from-source
     The binary was installed from source (probably using "go install" in the cloned repository).
     Install the binary using "go install repositoryPath@latest" instead.
+    This seems like a known problem E001.
+    See https://github.com/Gelio/go-global-update/blob/main/TROUBLESHOOTING.md#e001---binaries-built-from-source
+    for more information.
 
 `, output.String())
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1151 @@
+{
+  "name": "go-global-update",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "markdown-toc": "^1.2.0",
+        "prettier": "^2.6.0"
+      }
+    },
+    "node_modules/ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "dependencies": {
+        "ansi-wrap": "0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "dev": true,
+      "dependencies": {
+        "gulp-header": "^1.7.1"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "dev": true,
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "node_modules/diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+      "dev": true,
+      "dependencies": {
+        "ansi-red": "^0.1.1",
+        "coffee-script": "^1.12.4",
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.8.1",
+        "toml": "^2.3.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "deprecated": "Removed event-stream from gulp-header",
+      "dev": true,
+      "dependencies": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-object/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "node_modules/isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "dependencies": {
+        "isarray": "1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "dependencies": {
+        "is-buffer": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "dependencies": {
+        "set-getter": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+      "dev": true,
+      "dependencies": {
+        "expand-range": "^1.8.1",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "repeat-string": "^1.5.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "node_modules/lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "node_modules/lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "node_modules/markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "dev": true,
+      "dependencies": {
+        "concat-stream": "^1.5.2",
+        "diacritics-map": "^0.1.0",
+        "gray-matter": "^2.1.0",
+        "lazy-cache": "^2.0.2",
+        "list-item": "^1.1.1",
+        "markdown-link": "^0.1.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "object.pick": "^1.2.0",
+        "remarkable": "^1.7.1",
+        "repeat-string": "^1.6.1",
+        "strip-color": "^0.1.0"
+      },
+      "bin": {
+        "markdown-toc": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "node_modules/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "node_modules/mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "dependencies": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/mixin-deep/node_modules/is-extendable": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-object": "^2.0.4"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "dependencies": {
+        "isobject": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object.pick/node_modules/isobject": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "node_modules/randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/randomatic/node_modules/is-number": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+      "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/randomatic/node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
+      },
+      "bin": {
+        "remarkable": "bin/remarkable.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/set-getter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+      "dev": true,
+      "dependencies": {
+        "to-object-path": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "dependencies": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "node_modules/to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "dependencies": {
+        "kind-of": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/toml": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+      "dev": true
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    }
+  },
+  "dependencies": {
+    "ansi-red": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
+      "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "autolinker": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/autolinker/-/autolinker-0.28.1.tgz",
+      "integrity": "sha1-BlK0kYgYefB3XazgzcoyM5QqTkc=",
+      "dev": true,
+      "requires": {
+        "gulp-header": "^1.7.1"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "concat-with-sourcemaps": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/concat-with-sourcemaps/-/concat-with-sourcemaps-1.1.0.tgz",
+      "integrity": "sha512-4gEjHJFT9e+2W/77h/DS5SGUgwDaOwprX8L/gl5+3ixnzkVJJsZWDSelmN3Oilw3LNDZjZV0yqH1hLG3k6nghg==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "diacritics-map": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/diacritics-map/-/diacritics-map-0.1.0.tgz",
+      "integrity": "sha1-bfwP+dAQAKLt8oZTccrDFulJd68=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+      "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+      "dev": true,
+      "requires": {
+        "fill-range": "^2.1.0"
+      }
+    },
+    "extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
+      "requires": {
+        "is-extendable": "^0.1.0"
+      }
+    },
+    "fill-range": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "dev": true,
+      "requires": {
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^3.0.0",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+      "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "gray-matter": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-2.1.1.tgz",
+      "integrity": "sha1-MELZrewqHe1qdwep7SOA+KF6Qw4=",
+      "dev": true,
+      "requires": {
+        "ansi-red": "^0.1.1",
+        "coffee-script": "^1.12.4",
+        "extend-shallow": "^2.0.1",
+        "js-yaml": "^3.8.1",
+        "toml": "^2.3.2"
+      }
+    },
+    "gulp-header": {
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
+      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
+      "dev": true,
+      "requires": {
+        "concat-with-sourcemaps": "*",
+        "lodash.template": "^4.4.0",
+        "through2": "^2.0.0"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+      "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "is-plain-object": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "dev": true,
+      "requires": {
+        "isarray": "1.0.0"
+      }
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
+    },
+    "lazy-cache": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+      "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+      "dev": true,
+      "requires": {
+        "set-getter": "^0.1.0"
+      }
+    },
+    "list-item": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/list-item/-/list-item-1.1.1.tgz",
+      "integrity": "sha1-DGXQDih8tmPMs8s4Sad+iewmilY=",
+      "dev": true,
+      "requires": {
+        "expand-range": "^1.8.1",
+        "extend-shallow": "^2.0.1",
+        "is-number": "^2.1.0",
+        "repeat-string": "^1.5.2"
+      }
+    },
+    "lodash._reinterpolate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+      "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+      "dev": true
+    },
+    "lodash.template": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0",
+        "lodash.templatesettings": "^4.0.0"
+      }
+    },
+    "lodash.templatesettings": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
+      "dev": true,
+      "requires": {
+        "lodash._reinterpolate": "^3.0.0"
+      }
+    },
+    "markdown-link": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-link/-/markdown-link-0.1.1.tgz",
+      "integrity": "sha1-MsXGUZmmRXMWMi0eQinRNAfIx88=",
+      "dev": true
+    },
+    "markdown-toc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-toc/-/markdown-toc-1.2.0.tgz",
+      "integrity": "sha512-eOsq7EGd3asV0oBfmyqngeEIhrbkc7XVP63OwcJBIhH2EpG2PzFcbZdhy1jutXSlRBBVMNXHvMtSr5LAxSUvUg==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.5.2",
+        "diacritics-map": "^0.1.0",
+        "gray-matter": "^2.1.0",
+        "lazy-cache": "^2.0.2",
+        "list-item": "^1.1.1",
+        "markdown-link": "^0.1.1",
+        "minimist": "^1.2.0",
+        "mixin-deep": "^1.1.3",
+        "object.pick": "^1.2.0",
+        "remarkable": "^1.7.1",
+        "repeat-string": "^1.6.1",
+        "strip-color": "^0.1.0"
+      }
+    },
+    "math-random": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "dev": true
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "mixin-deep": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "dev": true,
+      "requires": {
+        "for-in": "^1.0.2",
+        "is-extendable": "^1.0.1"
+      },
+      "dependencies": {
+        "is-extendable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
+          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "dev": true,
+          "requires": {
+            "is-plain-object": "^2.0.4"
+          }
+        }
+      }
+    },
+    "object.pick": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
+      "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
+      "dev": true,
+      "requires": {
+        "isobject": "^3.0.1"
+      },
+      "dependencies": {
+        "isobject": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+          "dev": true
+        }
+      }
+    },
+    "prettier": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.0.tgz",
+      "integrity": "sha512-m2FgJibYrBGGgQXNzfd0PuDGShJgRavjUoRCw1mZERIWVSXF0iLzLm+aOqTAbLnC3n6JzUhAA8uZnFVghHJ86A==",
+      "dev": true
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "randomatic": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "dev": true,
+      "requires": {
+        "is-number": "^4.0.0",
+        "kind-of": "^6.0.0",
+        "math-random": "^1.0.1"
+      },
+      "dependencies": {
+        "is-number": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
+        },
+        "kind-of": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "dev": true
+        }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "remarkable": {
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/remarkable/-/remarkable-1.7.4.tgz",
+      "integrity": "sha512-e6NKUXgX95whv7IgddywbeN/ItCkWbISmc2DiqHJb0wTrqZIexqdco5b8Z3XZoo/48IdNVKM9ZCvTPJ4F5uvhg==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.10",
+        "autolinker": "~0.28.0"
+      }
+    },
+    "repeat-element": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "dev": true
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "set-getter": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.1.tgz",
+      "integrity": "sha512-9sVWOy+gthr+0G9DzqqLaYNA7+5OKkSmcqjL9cBpDEaZrr3ShQlyX2cZ/O/ozE41oxn/Tt0LGEM/w4Rub3A3gw==",
+      "dev": true,
+      "requires": {
+        "to-object-path": "^0.3.0"
+      }
+    },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "strip-color": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/strip-color/-/strip-color-0.1.0.tgz",
+      "integrity": "sha1-EG9l09PmotlAHKwOsM6LinArT3s=",
+      "dev": true
+    },
+    "through2": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "~2.3.6",
+        "xtend": "~4.0.1"
+      }
+    },
+    "to-object-path": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
+      "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
+      "dev": true,
+      "requires": {
+        "kind-of": "^3.0.2"
+      }
+    },
+    "toml": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
+      "integrity": "sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==",
+      "dev": true
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "devDependencies": {
+    "markdown-toc": "^1.2.0",
+    "prettier": "^2.6.0"
+  },
+  "scripts": {
+    "generate-toc:readme": "markdown-toc -i ./README.md",
+    "generate-toc:troubleshooting": "markdown-toc -i ./TROUBLESHOOTING.md",
+    "generate-toc": "npm run generate-toc:readme && npm run generate-toc:troubleshooting",
+    "format-docs:check": "prettier --check *.md",
+    "format-docs:write": "prettier --write *.md"
+  }
+}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -25,10 +25,10 @@ var mainGoBinaryPath string = filepath.Join("..", "main.go")
 // could serve as GOBIN for a test.
 func prepareTempGobin(t *testing.T) string {
 	gobin, err := ioutil.TempDir(INTEGRATION_TESTS_DIR, "test-")
-	require.Nil(t, err)
+	require.Nil(t, err, "could not create a temporary directory for GOBIN")
 
 	gobin, err = filepath.Abs(gobin)
-	require.Nil(t, err)
+	require.Nil(t, err, "could not get the absolute directory of GOBIN")
 
 	return gobin
 }
@@ -52,8 +52,8 @@ func newGoGlobalUpdateCommand(t *testing.T, gobin string, args ...string) *exec.
 }
 
 func installBinary(t *testing.T, gobin, pathURL string) {
-	err := newTestCommand(t, gobin, "go", "install", pathURL).Run()
-	require.Nil(t, err)
+	output, err := newTestCommand(t, gobin, "go", "install", pathURL).CombinedOutput()
+	require.Nilf(t, err, "could not install binary %s in GOBIN %s\noutput: %s", pathURL, gobin, string(output))
 }
 
 func getVersion(t *testing.T, gobin, binaryName string) (string, error) {
@@ -74,7 +74,7 @@ func binaryName(baseName string) string {
 }
 
 func ensureIntegrationTestsDirExists(t *testing.T) {
-	require.Nil(t, os.MkdirAll(INTEGRATION_TESTS_DIR, os.ModePerm))
+	require.Nil(t, os.MkdirAll(INTEGRATION_TESTS_DIR, os.ModePerm), "could not create a directory for integration tests at", INTEGRATION_TESTS_DIR)
 }
 
 func TestIntegration(t *testing.T) {
@@ -92,7 +92,7 @@ func TestIntegration(t *testing.T) {
 			require.Contains(t, version, "v0.2.0")
 		},
 		afterUpdate: func(t *testing.T, version string) {
-			assert.NotContains(t, version, "v0.2.0")
+			assert.NotContains(t, version, "v0.2.0", "binary was unexpectedly updated")
 		},
 	}
 	shfmtBinaryToInstall := binaryToInstall{
@@ -102,7 +102,7 @@ func TestIntegration(t *testing.T) {
 			require.Contains(t, version, "v3.4.2")
 		},
 		afterUpdate: func(t *testing.T, version string) {
-			assert.NotContains(t, version, "v3.4.2")
+			assert.NotContains(t, version, "v3.4.2", "binary was unexpectedly updated")
 		},
 	}
 
@@ -116,7 +116,7 @@ func TestIntegration(t *testing.T) {
 			binariesToInstall: []binaryToInstall{gofumptBinaryToInstall},
 		},
 		{
-			name:              "multiple binary",
+			name:              "multiple binaries",
 			binariesToInstall: []binaryToInstall{gofumptBinaryToInstall, shfmtBinaryToInstall},
 		},
 		{
@@ -168,16 +168,16 @@ func TestIntegration(t *testing.T) {
 
 			for _, binary := range c.binariesToInstall {
 				version, err := getVersion(t, gobin, binary.name)
-				require.Nil(t, err)
+				require.Nilf(t, err, "could not get version of %s before updating", binary.name)
 				binary.beforeUpdate(t, version)
 			}
 
-			err := newGoGlobalUpdateCommand(t, gobin, c.updateArgs...).Run()
-			assert.Nil(t, err)
+			output, err := newGoGlobalUpdateCommand(t, gobin, c.updateArgs...).CombinedOutput()
+			assert.Nilf(t, err, "could not run go-global-update command with args: %v\noutput: %s", c.updateArgs, string(output))
 
 			for _, binary := range c.binariesToInstall {
 				version, err := getVersion(t, gobin, binary.name)
-				require.Nil(t, err)
+				require.Nilf(t, err, "could not get version of %s after updating", binary.name)
 				binary.afterUpdate(t, version)
 			}
 
@@ -197,16 +197,16 @@ func TestBuiltFromSourceCommandLineArguments(t *testing.T) {
 	defer os.RemoveAll(gobin)
 
 	builtBinaryName := binaryName("built-binary")
-	err := newTestCommand(t, gobin, "go", "build", "-o", filepath.Join(gobin, builtBinaryName), mainGoBinaryPath).Run()
-	require.Nil(t, err)
+	output, err := newTestCommand(t, gobin, "go", "build", "-o", filepath.Join(gobin, builtBinaryName), mainGoBinaryPath).CombinedOutput()
+	require.Nilf(t, err, "could not build %s\noutput: %s", mainGoBinaryPath, string(output))
 
-	output, err := newGoGlobalUpdateCommand(t, gobin, builtBinaryName).Output()
-	assert.Nil(t, err)
+	output, err = newGoGlobalUpdateCommand(t, gobin, builtBinaryName).CombinedOutput()
+	assert.Nilf(t, err, "could not run go-global-update for %s\noutput: %s", builtBinaryName, string(output))
 	assert.Contains(t, string(output), fmt.Sprintf("%s (version: (devel), cannot upgrade)", builtBinaryName))
 	assert.Contains(t, string(output), "binary was built from source")
 
 	version, err := newTestCommand(t, gobin, "go", "version", "-m", filepath.Join(gobin, builtBinaryName)).Output()
-	assert.Nil(t, err)
+	assert.Nil(t, err, "could not get version of", builtBinaryName)
 	assert.Contains(t, string(version), "(devel)", "Binary was upgraded but binaries built from source should be skipped")
 }
 
@@ -220,22 +220,22 @@ func TestInstalledFromSource(t *testing.T) {
 	defer os.RemoveAll(gobin)
 
 	repositoryDir, err := filepath.Abs("..")
-	require.Nil(t, err)
+	require.Nil(t, err, "could not get the absolute filepath of the repository")
 
 	installCommand := newTestCommand(t, gobin, "go", "install")
 	installCommand.Dir = repositoryDir
 
 	err = installCommand.Run()
-	require.Nil(t, err)
+	require.Nil(t, err, "could not run go install for the go-global-update repository")
 
 	builtBinaryName := binaryName("go-global-update")
 	output, err := newGoGlobalUpdateCommand(t, gobin, builtBinaryName).Output()
-	assert.Nil(t, err)
+	assert.Nil(t, err, "could not run go-global-update for", builtBinaryName)
 	assert.Contains(t, string(output), fmt.Sprintf("%s (version: (devel), can upgrade to v", builtBinaryName))
 	assert.Contains(t, string(output), "binary was installed from source")
 
 	version, err := newTestCommand(t, gobin, "go", "version", "-m", filepath.Join(gobin, builtBinaryName)).Output()
-	assert.Nil(t, err)
+	assert.Nil(t, err, "could not get version of", builtBinaryName)
 	assert.Contains(t, string(version), "(devel)", "Binary was upgraded but binaries built from source should be skipped")
 }
 
@@ -277,7 +277,7 @@ func TestDetectCommonProblems(t *testing.T) {
 			defer os.RemoveAll(gobin)
 
 			err := c.installCommand(t, gobin).Run()
-			require.Nil(t, err)
+			require.Nil(t, err, "could not run install command")
 
 			builtBinaryName := binaryName(c.binaryName)
 			output, err := newGoGlobalUpdateCommand(t, gobin, builtBinaryName).Output()


### PR DESCRIPTION
Include more context in case a known problem is encountered during an update of a binary. There are currently 4 types of known issues which are described in a TROUBLESHOOTING.md file. Links to relevant sections in that file are printed to the console while running `go-global-update` and such a common problem is detected.

This PR also adds automatically generating table of contents in some Markdown files using https://github.com/jonschlinkert/markdown-toc and formatting of Markdown files using https://prettier.io/. Both of these are checked in CI.

Moreover, during the course of this PR [gofumpt@v0.3.1 was released](https://github.com/mvdan/gofumpt/releases/tag/v0.3.1) which [uses a `go:build` comment in the tests code](https://github.com/mvdan/gofumpt/compare/v0.3.0...v0.3.1#diff-ca480376222e952d215192a5258112ec9e3d94b35a4aceca38fbf987f331d16aR5). [Updating to gofumpt@v0.3.1 on go 1.16 fails with the following error](https://github.com/Gelio/go-global-update/runs/5640347027?check_suite_focus=true):

```
Upgrading gofumpt to v0.3.1 ... ❌
        Could not upgrade package
    go: downloading mvdan.cc/gofumpt v0.3.1
    go: downloading golang.org/x/sync v0.0.0-2021022003[29](https://github.com/Gelio/go-global-update/runs/5640347027?check_suite_focus=true#step:6:29)51-036812b2e83c
    go: downloading golang.org/x/sys v0.0.0-20220[31](https://github.com/Gelio/go-global-update/runs/5640347027?check_suite_focus=true#step:6:31)9134239-a9b59b0215f8
    go: downloading github.com/google/go-cmp v0.5.7
    go: downloading golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
    go: downloading golang.org/x/tools v0.1.10
    //go:build comment without // +build comment
```

I changed the tests to use https://github.com/google/gnostic as the binary to install instead of gofumpt. It seems to work on go 1.16. This surfaces a flaw with the integration tests - they rely on the code of the latest version of the binaries. They are not idempotent and can fail in the future because a new version of some binary was released even though the code changed.

Closes #4 