### PR TITLE
Add CLI short option alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+### Added
+
+- Short aliases for `--dry-run` and `--verbose` flags.
+
+  There are new alases for some of the options that the tools accepts:
+
+  - `-n` is an alias for `--dry-run`
+  - `-v` is an alias for `--verbose`
+
+  This should make it easier to use the tool for experienced users.
+
+  **BREAKING CHANGE**: a potential breaking change is that the `-v` flag was
+  previously an alias for `--version` and now is an alias for `--verbose`.
+  Running `go-global-update -v` will run the update process instead of only
+  printing the version. To print the version, use the `-V` flag (or the full
+  `--version` flag).
+
 ## v0.2.0 (2022-04-02)
 
 ### Improved

--- a/main.go
+++ b/main.go
@@ -19,6 +19,14 @@ import (
 func main() {
 	loggerConfig := zap.NewDevelopmentConfig()
 
+	// NOTE: re-define the version flag to use `V` instead of `v` as the alias
+	// `-v` belongs to the `--verbose` flag
+	cli.VersionFlag = &cli.BoolFlag{
+		Name:    "version",
+		Aliases: []string{"V"},
+		Usage:   "print the version",
+	}
+
 	app := &cli.App{
 		Name: "go-global-update",
 		Usage: `Update globally installed go binaries.
@@ -38,12 +46,14 @@ func main() {
 				Usage: "Display debug information",
 			},
 			&cli.BoolFlag{
-				Name:  "dry-run",
-				Usage: "Check which binaries are upgradable without actually installing new versions",
+				Name:    "dry-run",
+				Aliases: []string{"n"},
+				Usage:   "Check which binaries are upgradable without actually installing new versions",
 			},
 			&cli.BoolFlag{
-				Name:  "verbose",
-				Usage: "Include more detailed information in the logs",
+				Name:    "verbose",
+				Aliases: []string{"v"},
+				Usage:   "Include more detailed information in the logs",
 			},
 			&cli.BoolFlag{
 				Name:  "colors",

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 			},
 			&cli.BoolFlag{
 				Name:  "colors",
-				Usage: "Force using ANSI color codes in the output even if the output is not a TTY.\n\t\tSet the `NO_COLOR` environment variable if you want to force-disable colors (see https://no-color.org/).",
+				Usage: "Force using ANSI color codes in the output even if the output is not a TTY.\n\t\tSet the NO_COLOR environment variable if you want to force-disable colors (see https://no-color.org/).",
 			},
 		},
 		Action: func(c *cli.Context) error {


### PR DESCRIPTION
Add shorter aliases for the existing options:

* `-n` as an alias for `--dry-run`
* `-v` as an alias for `--verbose`

`-v` was previously used as an alias for `--version`. A shorter alias for `--version` is now `-V`. This could be a breaking change and is described in the CHANGELOG as such.

This matches the flags accepted by some POSIX tools.

Sadly, https://github.com/urfave/cli does not seem to be supporting providing multiple short options in a single argument prefixed by `-`:

```sh
16:42 $ go run main.go -nv
Incorrect Usage. flag provided but not defined: -nv
```

Providing those 2 flags as separate arguments works fine:

```
16:42 $ go run main.go -n -v
Binary                                        Current version      Status
github.com/Gelio/go-global-update             v0.2.0               up-to-date
mvdan.cc/gofumpt                              v0.3.1               up-to-date
github.com/xxxserxxx/gotop/v4/cmd/gotop       v4.1.2               can upgrade to v4.1.3
github.com/client9/misspell/cmd/misspell      v0.3.4               up-to-date
mvdan.cc/sh/v3/cmd/shfmt                      v3.4.3               up-to-date
```


I have also fixed the `--help` output for the `--colors` flag. Before, the `NO_COLOR` text was placed right after the `--colors` flag, which looked like `--colors NO_COLOR` and resembled that `NO_COLOR` is a value for the `--colors` flag. In reality, they are opposites of each other and should be used separately.

Closes #15