### PR TITLE
fix(cli): allow combining multiple short options into one arg

### DIFF
--- a/main.go
+++ b/main.go
@@ -38,8 +38,9 @@ func main() {
 
    * go-global-update gofumpt gopls shfmt
    * go-global-update --dry-run`,
-		Version:   "v0.2.1",
-		ArgsUsage: "[binaries to update...]",
+		Version:                "v0.2.1",
+		ArgsUsage:              "[binaries to update...]",
+		UseShortOptionHandling: true,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "debug",


### PR DESCRIPTION
Enable short option handling for CLI arguments. Allows using multiple single-letter flags in a single CLI argument. For example:

```sh
go-global-update -nv
```

is equivalent to:

```sh
go-global-update -n -v
```

This matches the standard POSIX behavior.

See https://github.com/urfave/cli/blob/master/docs/v2/manual.md#combining-short-options

Related to #15 