### PR TITLE
chore: include go 1.19 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ["1.16", "1.17", "1.18"]
+        go-version: ["1.16", "1.17", "1.18", "1.19"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Continue other jobs if one matrix job fails
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Include go 1.19 in CI <https://github.com/Gelio/go-global-update/pull/18>.
+
 ## v0.2.2 (2022-04-03)
 
 ### Fixed


### PR DESCRIPTION
[Go 1.19 release notes](https://tip.golang.org/doc/go1.19)

Let's include it in CI to make sure the tool works on that go version as well.