### PR TITLE
Update versions of go and GitHub actions used in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -45,8 +45,8 @@ jobs:
   verify-table-of-contents:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
           node-version: "18"
       - run: npm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ["1.17", "1.18", "1.19", "1.20"]
+        go-version: ["1.18", "1.19", "1.20", "1.21", "stable"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Continue other jobs if one matrix job fails
       fail-fast: false
@@ -25,7 +25,8 @@ jobs:
         # NOTE: only verify formatting on Linux and the latest go version.
         # It only needs to happen once, and formatting
         # is not consistent on Windows.
-        if: ${{ startsWith(matrix.os, 'ubuntu') && matrix.go-version == '1.20'}}
+        if:
+          ${{ startsWith(matrix.os, 'ubuntu') && matrix.go-version == 'stable'}}
 
         # NOTE: hacky bash `if` because gofumpt always returns 0 exit code
         # @see https://github.com/mvdan/gofumpt/issues/114


### PR DESCRIPTION
Let's update the versions of the go binary, as well as the GitHub actions used in CI jobs.

This should fix the CI error on go 1.17.