### PR TITLE
Add `--force` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## Added
+
+- A new `--force` flag (alias: `-f`)
+  <https://github.com/Gelio/go-global-update/pull/23>.
+
+  The `--force` flag forces reinstalling binaries that are already up-to-date
+  and would otherwise be skipped when upgrading the versions.
+
+  This can be used to reinstall all binaries after a new version of go is
+  installed, especially when it fixes security vulnerabilities.
+
+  Thanks to [@thejan2009](https://github.com/thejan2009) for suggesting this
+  feature.
+
 ## v0.2.3 (2023-09-19)
 
 ### Improvements

--- a/main.go
+++ b/main.go
@@ -60,6 +60,11 @@ func main() {
 				Name:  "colors",
 				Usage: "Force using ANSI color codes in the output even if the output is not a TTY.\n\t\tSet the NO_COLOR environment variable if you want to force-disable colors (see https://no-color.org/).",
 			},
+			&cli.BoolFlag{
+				Name:    "force",
+				Aliases: []string{"f"},
+				Usage:   "Force reinstall all binaries, even if they do not need to be updated",
+			},
 		},
 		Action: func(c *cli.Context) error {
 			forceColors := c.Bool("colors")
@@ -78,6 +83,7 @@ func main() {
 				updater.Options{
 					DryRun:           c.Bool("dry-run"),
 					Verbose:          c.Bool("verbose"),
+					ForceReinstall:   c.Bool("force"),
 					BinariesToUpdate: c.Args().Slice(),
 				},
 				os.Stdout,

--- a/main.go
+++ b/main.go
@@ -78,14 +78,20 @@ func main() {
 
 			cmdRunner := gocli.NewCmdRunner(logger)
 
+			options := updater.Options{
+				DryRun:           c.Bool("dry-run"),
+				Verbose:          c.Bool("verbose"),
+				ForceReinstall:   c.Bool("force"),
+				BinariesToUpdate: c.Args().Slice(),
+			}
+
+			if options.DryRun && options.ForceReinstall {
+				return fmt.Errorf("--dry-run and --force options cannot be used together")
+			}
+
 			err = updater.UpdateBinaries(
 				logger,
-				updater.Options{
-					DryRun:           c.Bool("dry-run"),
-					Verbose:          c.Bool("verbose"),
-					ForceReinstall:   c.Bool("force"),
-					BinariesToUpdate: c.Args().Slice(),
-				},
+				options,
 				os.Stdout,
 				&colorsDecoratorFactory,
 				&cmdRunner,

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -127,7 +127,7 @@ func TestIntegration(t *testing.T) {
 					name:           gnosticBinaryToInstall.name,
 					pathAndVersion: gnosticBinaryToInstall.pathAndVersion,
 					beforeUpdate:   gnosticBinaryToInstall.beforeUpdate,
-					// NOTE: the gofumpt binary should not be upgraded
+					// NOTE: the binary should not be upgraded
 					afterUpdate: gnosticBinaryToInstall.beforeUpdate,
 				},
 			},


### PR DESCRIPTION
This PR introduces a new `--force` flag (alias: -f). It overrides the upgrade behavior to force reinstall binaries when they do not have a new version available.

The option can be used when a new version of go is released that fixes vulnerabilities and the user wants to reinstall all the binaries using the new version.

This option cannot be used alongside the `--dry-run` option, since their behavior is opposite.

Closes https://github.com/Gelio/go-global-update/issues/22