### PR TITLE
ci: include go 1.22 in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ["1.18", "1.19", "1.20", "1.21", "stable"]
+        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22", "stable"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Continue other jobs if one matrix job fails
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-## Added
+### Added
 
 - A new `--force` flag (alias: `-f`)
   <https://github.com/Gelio/go-global-update/pull/23>.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@
   Thanks to [@thejan2009](https://github.com/thejan2009) for suggesting this
   feature.
 
+### Internal
+
+- Include go 1.22 in CI <https://github.com/Gelio/go-global-update/pull/24>.
+
 ## v0.2.3 (2023-09-19)
 
 ### Improvements


### PR DESCRIPTION
Make sure the tool also works using go 1.22.