### PR TITLE
chore: release v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## v0.2.4 (2024-06-10)
+
 ### Added
 
 - A new `--force` flag (alias: `-f`)

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 
    * go-global-update gofumpt gopls shfmt
    * go-global-update --dry-run`,
-		Version:                "v0.2.3",
+		Version:                "v0.2.4",
 		ArgsUsage:              "[binaries to update...]",
 		UseShortOptionHandling: true,
 		Flags: []cli.Flag{


### PR DESCRIPTION
### Added

- A new `--force` flag (alias: `-f`) <https://github.com/Gelio/go-global-update/pull/23>.

  The `--force` flag forces reinstalling binaries that are already up-to-date and would otherwise be skipped when upgrading the versions.

  This can be used to reinstall all binaries after a new version of go is installed, especially when it fixes security vulnerabilities.

  Thanks to [@thejan2009](https://github.com/thejan2009) for suggesting this feature.

### Internal

- Include go 1.22 in CI <https://github.com/Gelio/go-global-update/pull/24>.
