### PR TITLE
Preserve build tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Added
+
+- Preserve build tags when updating/reinstalling binaries
+  <https://github.com/Gelio/go-global-update/pull/29>
+
+  Binaries installed with `go install -tags a,b,c ...` (build tags) will have
+  the build tags preserved when updating them. This means that the `go install`
+  command that `go-global-update` runs internally will also include the same
+  build tags.
+
+  This behavior is enabled by default and there is no flag to disable it.
+
+  This only affects binaries that were installed with build tags.
+
+  See
+  [Customizing Go Binaries with Build Tags](https://www.digitalocean.com/community/tutorials/customizing-go-binaries-with-build-tags)
+  for more information about build tags.
+
+  Fixes <https://github.com/Gelio/go-global-update/issues/28>.
+
 ### Internal
 
 - Include go 1.23 and drop versions earlier than 1.21 in CI

--- a/internal/gobinaries/gobinary.go
+++ b/internal/gobinaries/gobinary.go
@@ -10,6 +10,12 @@ type GoBinary struct {
 	Path          string
 	Version       string
 	LatestVersion string
+
+	// Build tags that were used to build the binary.
+	// They correspond to the `-tags` option in `go build`.
+	//
+	// When updating a binary, the same build tags should be used.
+	BuildTags []string
 }
 
 func (b *GoBinary) UpgradePossible() bool {

--- a/internal/gobinaries/introspecter_test.go
+++ b/internal/gobinaries/introspecter_test.go
@@ -166,3 +166,79 @@ go-global-update: go1.18
 	assert.True(t, binary.BuiltFromSource())
 	assert.True(t, binary.BuiltWithGoBuild())
 }
+
+func TestFindBuildTag(t *testing.T) {
+	for _, test := range []struct {
+		buildTagsArray  []string
+		buildTagsString string
+	}{
+		{
+			buildTagsArray:  []string{"a", "b", "c"},
+			buildTagsString: "a,b,c",
+		},
+		{
+			buildTagsArray:  []string{"a"},
+			buildTagsString: "a",
+		},
+	} {
+
+		test := test
+		t.Run(test.buildTagsString, func(t *testing.T) {
+			mockBinary := gobinariestest.MockBinary{
+				Binary: gobinaries.GoBinary{
+					Name:      "go-global-update",
+					Path:      filepath.Join(gobinariestest.GOBIN, "go-global-update"),
+					PathURL:   "github.com/Gelio/go-global-update",
+					ModuleURL: "github.com/Gelio/go-global-update",
+					Version:   "(devel)",
+					BuildTags: test.buildTagsArray,
+				},
+				ModuleInfo: fmt.Sprintf(`
+go-global-update: go1.23.1
+		path    github.com/Gelio/go-global-update
+		mod     github.com/Gelio/go-global-update       (devel)
+		dep     github.com/cpuguy83/go-md2man/v2        v2.0.0-20190314233015-f79a8a8ca69d      h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+		dep     github.com/fatih/color  v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
+		dep     github.com/mattn/go-colorable   v0.1.9  h1:sqDoxXbdeALODt0DAeJCVp38ps9ZogZEAXjus69YV3U=
+		dep     github.com/mattn/go-isatty      v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
+		dep     github.com/russross/blackfriday/v2      v2.0.1  h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+		dep     github.com/shurcooL/sanitized_anchor_name       v1.0.0  h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+		dep     github.com/urfave/cli/v2        v2.3.0  h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
+		dep     go.uber.org/atomic      v1.9.0  h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
+		dep     go.uber.org/multierr    v1.8.0  h1:dg6GjLku4EH+249NNmoIciG9N/jURbDG+pFlTkhzIC8=
+		dep     go.uber.org/zap v1.21.0 h1:WefMeulhovoZ2sYXz7st6K0sLj7bBhpiFaud4r4zST8=
+		dep     golang.org/x/sys        v0.0.0-20210630005230-0f9fa26af87c      h1:F1jZWGFhYfh0Ci55sIpILtKKK8p3i2/krTr0H1rg74I=
+		build   -buildmode=exe
+		build   -compiler=gc
+		build   -tags=%s
+		build   DefaultGODEBUG=asynctimerchan=1,gotypesalias=0,httplaxcontentlength=1,httpmuxgo121=1,httpservecontentkeepheaders=1,netedns0=0,panicnil=1,tls10server=1,tls3des=1,tlskyber=0,tlsrsakex=1,tlsunsafeekm=1,winreadlinkvolume=0,winsymlink=0,x509keypairleaf=0,x509negativeserial=1
+		build   CGO_ENABLED=1
+		build   CGO_CFLAGS=
+		build   CGO_CPPFLAGS=
+		build   CGO_CXXFLAGS=
+		build   CGO_LDFLAGS=
+		build   GOARCH=arm64
+		build   GOOS=darwin
+		build   GOARM64=v8.0
+		build   vcs=git
+		build   vcs.revision=33e1a9214aa901d9c65c1143cff963f8bed3fc18
+		build   vcs.time=2024-06-10T08:06:39Z
+		build   vcs.modified=true
+`, test.buildTagsString),
+			}
+
+			cmdRunner := goclitest.TestGoCmdRunner{
+				Responses: []goclitest.MockResponse{
+					gobinariestest.GetModuleInfoMockResponse(mockBinary),
+					gobinariestest.GetLatestVersionMockResponse(mockBinary.Binary),
+				},
+			}
+
+			introspecter := gobinaries.NewIntrospecter(&cmdRunner, gobinariestest.GOBIN, zap.NewNop())
+
+			binary, err := introspecter.Introspect(mockBinary.Binary.Name)
+			assert.Nil(t, err)
+			assert.Equal(t, mockBinary.Binary, binary)
+		})
+	}
+}

--- a/internal/gocli/gocli.go
+++ b/internal/gocli/gocli.go
@@ -2,6 +2,7 @@ package gocli
 
 import (
 	"fmt"
+	"strings"
 )
 
 func New(cmdRunner GoCmdRunner) GoCLI {
@@ -18,7 +19,15 @@ func (cli *GoCLI) GetEnvVar(name string) (string, error) {
 	return cli.cmdRunner.RunGoCommand("env", name)
 }
 
-func (cli *GoCLI) UpgradePackage(name string) (string, error) {
+func (cli *GoCLI) UpgradePackage(name string, buildTags []string) (string, error) {
+	args := []string{"install"}
+
+	if len(buildTags) > 0 {
+		args = append(args, "-tags", strings.Join(buildTags, ","))
+	}
+
 	packageNameWithVersion := fmt.Sprintf("%s@latest", name)
-	return cli.cmdRunner.RunGoCommand("install", packageNameWithVersion)
+	args = append(args, packageNameWithVersion)
+
+	return cli.cmdRunner.RunGoCommand(args...)
 }

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	"text/tabwriter"
 
 	"github.com/Gelio/go-global-update/internal/colors"
@@ -178,14 +179,19 @@ func updateBinaries(
 	latestVersionFormatter := colorsFactory.NewDecorator(color.FgGreen)
 
 	for _, binary := range binariesToUpdate {
-		if binary.UpgradePossible() {
-			fmt.Fprintf(out, "Upgrading %s to %s ... ", binaryNameFormatter(binary.Name),
-				latestVersionFormatter(binary.LatestVersion))
-		} else {
-			fmt.Fprintf(out, "Force-reinstalling %s %s ... ", binaryNameFormatter(binary.Name),
-				latestVersionFormatter(binary.LatestVersion))
+		var buildTagsInfo string
+		if len(binary.BuildTags) > 0 {
+			buildTagsInfo = fmt.Sprintf(" (build tags: %s)", faintFormatter(strings.Join(binary.BuildTags, ",")))
 		}
-		upgradeOutput, err := goCLI.UpgradePackage(binary.PathURL)
+
+		if binary.UpgradePossible() {
+			fmt.Fprintf(out, "Upgrading %s to %s%s ... ", binaryNameFormatter(binary.Name),
+				latestVersionFormatter(binary.LatestVersion), buildTagsInfo)
+		} else {
+			fmt.Fprintf(out, "Force-reinstalling %s %s%s ... ", binaryNameFormatter(binary.Name),
+				latestVersionFormatter(binary.LatestVersion), buildTagsInfo)
+		}
+		upgradeOutput, err := goCLI.UpgradePackage(binary.PathURL, binary.BuildTags)
 		if err != nil {
 			upgradeErrors = append(upgradeErrors, err)
 			fmt.Fprintln(out, "❌")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -2,7 +2,6 @@ package test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,7 +23,7 @@ var mainGoBinaryPath string = filepath.Join("..", "main.go")
 // prepareTempoGobin returns an absolute path to a temporary directory. It
 // could serve as GOBIN for a test.
 func prepareTempGobin(t *testing.T) string {
-	gobin, err := ioutil.TempDir(INTEGRATION_TESTS_DIR, "test-")
+	gobin, err := os.MkdirTemp(INTEGRATION_TESTS_DIR, "test-")
 	require.Nil(t, err, "could not create a temporary directory for GOBIN")
 
 	gobin, err = filepath.Abs(gobin)


### PR DESCRIPTION
`go-global-update` is now aware of build tags (`go install -tags a,b,c...`) that were used to install the binary. It will reuse the tags when updating/reinstalling packages.

This PR includes the feature, as well as unit and integration tests for it.

Fixes https://github.com/Gelio/go-global-update/issues/28