### PR TITLE
ci: include go 1.23 and drop go older than 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22", "stable"]
+        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22", "1.23", "stable"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Continue other jobs if one matrix job fails
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build-and-test:
     strategy:
       matrix:
-        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22", "1.23", "stable"]
+        go-version: ["1.21", "1.22", "1.23", "stable"]
         os: [ubuntu-latest, macos-latest, windows-latest]
       # Continue other jobs if one matrix job fails
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@
 
 ### Internal
 
-- Include go 1.23 in CI
+- Include go 1.23 and drop versions earlier than 1.21 in CI
+  <https://github.com/Gelio/go-global-update/pull/30>
+
+  The versions in CI now are closer to
+  [the Go release policy](https://go.dev/doc/devel/release). Go 1.21 is also
+  tested right now, even though it is no longer supported anymore.
+
+  This is mostly because
+  [the latest version of shfmt (v3.9.0)](https://github.com/mvdan/sh/releases/tag/v3.9.0)
+  no longer supports Go older than 1.21, and this breaks a lot of integration
+  tests. `go-global-update` itself should still work on earlier versions of Go,
+  but they are no longer tested in CI, and thus, no longer officially supported.
 
 ## v0.2.4 (2024-06-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+- Include go 1.23 in CI
+
 ## v0.2.4 (2024-06-10)
 
 ### Added


### PR DESCRIPTION
Run tests also on go 1.23 (the latest major version right now), and drop official support for go older than 1.21

See the commit messages for a deeper explanation.